### PR TITLE
add module to load environment variables from aws secretsmanager

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,8 +7,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: "checkout"
+        uses: actions/checkout@v4
+      - name: "setup python"
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,9 +1,19 @@
-name: mamster build
+name: ci
 on:
-  push:
-    branches: [ "master" ]
+  pull_request:
+    branches:
+    - master
 jobs:
-
-  todo:
-    uses: tracefy/github-actions-workflows/.github/workflows/utilities-todo.yml@v1
-    secrets: inherit
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: 'requirements-dev.txt'
+      - name: "pip install"
+        run: pip install -r requirements-dev.txt
+      - name: "pytest"
+        run: python -m pytest tests/**

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can install TracefyClients using pip:
 
 ```bash
 pip install TracefyClients
-``` 
+```
 
 Make sure to have the required dependencies listed in requirements.txt installed as well.
 
@@ -89,6 +89,25 @@ for _ in range(num_messages):
 
 ```
 
+### Secretsmanager environment loader
+The secretsmanager utiliy module lets you load your secrets into your environment at the start of your application
+
+```python
+from TracefyClients.secretsmanager import secretsmanager_loadenv
+
+if __name__ == "__main__":
+    # Using AWS_SECRETSMANAGER_SECRET_IDS env variable e.g. AWS_SECRETSMANAGER_SECRET_IDS="secret1,secret2"
+    # The secrets need to be a JSON object of key value pairs, where each value is strictly a string (otherwise a Exception is thrown)
+    # Example secret value: { "MYSQL_USER": "example-user", "MYSQL_PASSWORD": "example-password" }
+    # region_name can be excluded if AWS_DEFAULT_REGION is defined
+    secretsmanager_loadenv(region_name="eu-central-1")
+
+    # Or you can pass the secret names directly (both simple name or arn are supported)
+    secretsmanager_loadenv(secrets=["secret1", "secret2"], region_name="eu-central-1")
+
+    # Start orther clients that depend on those environment variables
+    sqs_client = SQSClient()
+```
 
 ## Configuration
 

--- a/TracefyClients/secretsmanager.py
+++ b/TracefyClients/secretsmanager.py
@@ -1,0 +1,147 @@
+import json
+import os
+import re
+from base64 import b64decode
+from typing import Any, Dict, List, Optional, final
+
+import boto3
+from mypy_boto3_secretsmanager.client import SecretsManagerClient
+from mypy_boto3_secretsmanager.type_defs import (
+    APIErrorTypeTypeDef,
+    BatchGetSecretValueResponseTypeDef,
+    GetSecretValueResponseTypeDef,
+    SecretValueEntryTypeDef,
+)
+
+BATCH_SIZE_LIMIT = 20
+DEFAULT_ENVKEY = "AWS_SECRETSMANAGER_SECRET_IDS"
+
+@final
+class InvalidSecretValueError(ValueError):
+    def __init__(self, secret_arn: str):
+        msg = f"secret {secret_arn} contains a value that is not a string or is not a valid json object"
+        return super(InvalidSecretValueError, self).__init__(msg)
+
+@final
+class BatchGetSecretValueError(RuntimeError):
+    def __init__(self, errors: List[APIErrorTypeTypeDef]):
+        msg = f"batch_get_secret_value errors: {json.dumps(json.dumps(errors))}"
+        return super(BatchGetSecretValueError, self).__init__(msg)
+
+
+# might use pydantic for this in the future
+def is_valid_secret_value(value: Dict[str, Any]) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return all(isinstance(v, str) for v in value.values())
+
+
+def parse_secret_value(
+    value: SecretValueEntryTypeDef | GetSecretValueResponseTypeDef,
+) -> Dict[str, str]:
+    """
+    Returns a decoded dictionary of the key value pairs contained inside a secret
+    Raises exceptions if the value is not valid json object or if the dictionary contains
+    non-string values
+    """
+
+    try:
+        is_string = "SecretString" in value
+        data: str | bytes = value["SecretString"] if is_string else b64decode(value["SecretBinary"])
+        ret = json.loads(data)
+    except ValueError:
+        raise InvalidSecretValueError(value["ARN"])
+    if not is_valid_secret_value(ret):
+        raise InvalidSecretValueError(value["ARN"])
+    return ret
+
+
+def parse_batch_response(
+    response: BatchGetSecretValueResponseTypeDef,
+) -> Dict[str, str]:
+    result = {}
+    for value in response.get("SecretValues", []):
+        result.update(parse_secret_value(value))
+    errors = response.get("Errors", [])
+    if len(errors) > 0:
+        raise BatchGetSecretValueError(errors)
+    return result
+
+
+def get_secret_value(client: SecretsManagerClient, secret: str) -> Dict[str, str]:
+    response = client.get_secret_value(SecretId=secret)
+    return parse_secret_value(response)
+
+
+def batch_get_secret_value(client: SecretsManagerClient, secrets: List[str]) -> Dict[str, str]:
+    response = client.batch_get_secret_value(SecretIdList=secrets)
+    return parse_batch_response(response)
+
+
+def get_values_from_secrets(client: SecretsManagerClient, secrets: List[str]) -> Dict[str, str]:
+    """
+    Only support for aws/secretsmanager encrypted secrets
+    Required permissions
+      secretsmanager:BatchGetSecretValue
+      secretsmanager:GetSecretValue (for each secret)
+
+    If two secrets have the same key they will overwrite each other.
+    The order of overwrites are may not be in the same order that the secrets occur in the list
+    so make sure there are no conflicting keys between two secrets
+    """
+
+    if len(secrets) == 1:
+        return get_secret_value(client, secrets[0])
+
+    chunks = (secrets[x : x + BATCH_SIZE_LIMIT] for x in range(0, len(secrets), BATCH_SIZE_LIMIT))
+    results = (batch_get_secret_value(client, chunk) for chunk in chunks)
+    return {k: v for r in results for k, v in r.items()}
+
+
+def load_dictionary_as_env(env: Dict[str, str], overwrite_existing_keys: bool):
+    """Set environment values from envmap dictionary"""
+
+    if overwrite_existing_keys:
+        for key, value in env.items():
+            os.environ[key] = value
+        return
+
+    for key, value in env.items():
+        if key in os.environ:
+            continue
+        os.environ[key] = value
+
+
+def secretsmanager_values(secrets: Optional[List[str]] = None, region_name: Optional[str] = None):
+    """
+    Returns a dictionary of the merged secret values found inside the comma separated
+    environment variable (default is AWS_SECRETSMANAGER_SECRET_IDS)
+
+    Call secretsmanager_values at the start of your application to use the secrets to configure
+    other for example other API clients
+    """
+
+    if secrets is None:
+        if DEFAULT_ENVKEY not in os.environ:
+            raise RuntimeError(f"parameter secrets and {DEFAULT_ENVKEY} not set")
+        secret_id = os.environ[DEFAULT_ENVKEY]
+        secrets = [e.strip() for e in secret_id.split(",")]
+
+    client = boto3.client("secretsmanager", region_name=region_name)
+    return get_values_from_secrets(client, secrets)
+
+
+def secretsmanager_loadenv(
+    secrets: Optional[List[str]] = None,
+    region_name: Optional[str] = None,
+    overwrite_existing_keys: bool = False,
+):
+    """
+    Loads key value pairs defined in the secret ids inside the comma separated
+    environment variable (default is AWS_SECRETSMANAGER_SECRET_IDS)
+
+    Call secretsmanager_loadenv at the start of your application
+    """
+
+    env = secretsmanager_values(secrets, region_name)
+    load_dictionary_as_env(env, overwrite_existing_keys)

--- a/TracefyClients/sqs_client.py
+++ b/TracefyClients/sqs_client.py
@@ -3,7 +3,7 @@ import brotli
 import base64
 import boto3
 import time
-from boto3_type_annotations.sqs import Message, Queue
+from mypy_boto3_sqs.service_resource import Message, Queue
 from botocore.exceptions import ConnectionClosedError
 from boto3.resources.base import ServiceResource
 import json

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+mypy==1.11.2
+pytest==8.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ pymongo==4.8.0
 Brotli==1.1.0
 # typing
 boto3-stubs==1.35.14
-boto3-stubs[secretsmanager]==1.35.14
+boto3-stubs[secretsmanager,sqs]==1.35.14
 types-Flask-Cors==5.0.0.20240902
 types-requests==2.32.0.20240905

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,15 @@ Flask-Cors==5.0.0
 python-dotenv==1.0.1
 sentry-sdk==2.13.0
 marshmallow==3.22.0
-pytest==8.3.2
-boto3==1.35.13
-boto3-type-annotations==0.3.1
+boto3==1.35.14
+botocore==1.35.14
 mysql-connector-python==9.0.0
 requests==2.32.3
 redis==5.0.8
 pymongo==4.8.0
 Brotli==1.1.0
+# typing
+boto3-stubs==1.35.14
+boto3-stubs[secretsmanager]==1.35.14
+types-Flask-Cors==5.0.0.20240902
+types-requests==2.32.0.20240905

--- a/tests/secretsmanager.py
+++ b/tests/secretsmanager.py
@@ -1,0 +1,168 @@
+import os
+import re
+import pytest
+import random
+import string
+import json
+import botocore.session
+from botocore.stub import Stubber
+import TracefyClients.secretsmanager as sm
+
+
+def response_value(name: str, value: str) -> any:
+    return {
+        "ARN": f"arn:aws:secretsmanager:region:account-id:secret:{name}-a1b2c3",
+        "Name": name,
+        "VersionId": "a1b2c3d4-5678-90ab-cdef-EXAMPLEaaaaa",
+        "SecretString": value,
+        "VersionStages": ["AWSCURRENT"],
+        "CreatedDate": 0,
+    }
+
+
+@pytest.fixture
+def setup_client():
+    client = botocore.session.get_session().create_client("secretsmanager", region_name="test")
+    stubber = Stubber(client)
+    return (client, stubber)
+
+
+@pytest.fixture
+def secret_fixture() -> (str, any):
+    return ("test", response_value("test", '{"host":"localhost","region":"eu"}'))
+
+
+def test_secretsmanager_multiple_secrets_uses_batch(setup_client):
+    (client, stubber) = setup_client
+    response = {
+        "Errors": [],
+        "SecretValues": [
+            response_value("secret", '{"username":"john","password":"pass"}'),
+            response_value("test", '{"host":"localhost","region":"eu"}'),
+        ],
+    }
+
+    expected_params = {"SecretIdList": ["secret", "test"]}
+    stubber.add_response("batch_get_secret_value", response, expected_params)
+    with stubber:
+        result = sm.get_values_from_secrets(client, ["secret", "test"])
+
+    expected = {
+        "username": "john",
+        "password": "pass",
+        "host": "localhost",
+        "region": "eu",
+    }
+    assert result == expected
+
+
+def test_secretsmanager_batch_error(setup_client):
+    (client, stubber) = setup_client
+    error = {"SecretId": "secret", "ErrorCode": "error_code", "Message": "message"}
+    response = {
+        "Errors": [error],
+        "SecretValues": [response_value("test", '{"host":"localhost"}')],
+    }
+
+    secrets = ["secret", "test"]
+    expected_params = {"SecretIdList": secrets}
+    stubber.add_response("batch_get_secret_value", response, expected_params)
+
+    error_string = '"[{\\"SecretId\\": \\"secret\\", \\"ErrorCode\\": \\"error_code\\", \\"Message\\": \\"message\\"}]"'
+    with pytest.raises(
+        sm.BatchGetSecretValueError,
+        match=re.escape(f"batch_get_secret_value errors: {error_string}"),
+    ):
+        with stubber:
+            result = sm.get_values_from_secrets(client, secrets)
+
+
+def test_secretsmanager_single_secret_request_use_single_get(setup_client, secret_fixture):
+    (client, stubber) = setup_client
+    (name, response) = secret_fixture
+    expected_params = {"SecretId": name}
+    stubber.add_response("get_secret_value", response, expected_params)
+
+    with stubber:
+        result = sm.get_values_from_secrets(client, [name])
+    assert result == {"host": "localhost", "region": "eu"}
+
+
+def test_secretsmanager_secret_is_not_json(setup_client, secret_fixture):
+    (client, stubber) = setup_client
+    (name, response) = secret_fixture
+    response["SecretString"] = "bad"
+    expected_params = {"SecretId": name}
+    stubber.add_response("get_secret_value", response, expected_params)
+
+    with pytest.raises(sm.InvalidSecretValueError):
+        with stubber:
+            result = sm.get_values_from_secrets(client, [name])
+
+
+def test_secretsmanager_secret_contains_non_string_value(setup_client, secret_fixture):
+    (client, stubber) = setup_client
+    (name, response) = secret_fixture
+    response["SecretString"] = '{"host": ["localhost"]}'
+    expected_params = {"SecretId": name}
+    stubber.add_response("get_secret_value", response, expected_params)
+
+    with pytest.raises(sm.InvalidSecretValueError):
+        with stubber:
+            result = sm.get_values_from_secrets(client, [name])
+
+
+def test_secretsmanager_loadenv(setup_client, secret_fixture):
+    (client, stubber) = setup_client
+    (name, response) = secret_fixture
+    expected_params = {"SecretId": name}
+    stubber.add_response("get_secret_value", response, expected_params)
+
+    # might need to also validate that keys are SCREAM_CASE
+    os.environ["host"] = "127.0.0.1"
+    assert "region" not in os.environ
+
+    with stubber:
+        result = sm.get_values_from_secrets(client, [name])
+        sm.load_dictionary_as_env(result, False)
+    assert os.environ["host"] == "127.0.0.1"
+    assert os.environ["region"] == "eu"
+
+    stubber.add_response("get_secret_value", response, expected_params)
+    with stubber:
+        result = sm.get_values_from_secrets(client, [name])
+        sm.load_dictionary_as_env(result, True)
+    assert os.environ["host"] == "localhost"
+    assert os.environ["region"] == "eu"
+
+
+def test_secretsmanager_batch_splitting(setup_client):
+    (client, stubber) = setup_client
+    secrets = ["".join(random.choice(string.ascii_letters) for _ in range(6)) for _ in range(25)]
+    response = [
+        {
+            "Errors": [],
+            "SecretValues": [
+                response_value(n, '{{"{0}": "{0}"}}'.format(n))
+                for n in secrets[0 : sm.BATCH_SIZE_LIMIT]
+            ],
+        },
+        {
+            "Errors": [],
+            "SecretValues": [
+                response_value(n, '{{"{0}": "{0}"}}'.format(n))
+                for n in secrets[sm.BATCH_SIZE_LIMIT :]
+            ],
+        },
+    ]
+    expected_params = [
+        {"SecretIdList": secrets[0 : sm.BATCH_SIZE_LIMIT]},
+        {"SecretIdList": secrets[sm.BATCH_SIZE_LIMIT :]},
+    ]
+    stubber.add_response("batch_get_secret_value", response[0], expected_params[0])
+    stubber.add_response("batch_get_secret_value", response[1], expected_params[1])
+    with stubber:
+        result = sm.get_values_from_secrets(client, secrets)
+
+    expected = {k: k for k in secrets}
+    assert result == expected


### PR DESCRIPTION
Allows application to load secrets into their process's environment at using secrets manager.
Future improvement would be to use caching system that refreshes the secrets every hour (see https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_cache-python.html)